### PR TITLE
WEB-297 - mobile display formats awards similar to desktop

### DIFF
--- a/public/assets/custom/css/custom.css
+++ b/public/assets/custom/css/custom.css
@@ -655,18 +655,27 @@ h5 strong a:hover {
 
   .award-container {
     text-align: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
   }
 
   .award-row {
-    margin-left: -10px;
+    margin-left: -10%;
+    margin-right: -10%;
     max-width: inherit;
     position: relative;
+    display: inline-block;
+  }
+  
+  .award-row + .award-row { /* Second Award Row */
+    margin-left: -3%; 
+    display: inline-block;
   }
 
   .award-overlapped-first {
     position: relative;
     left: 0%;
-    margin-top: 10px;
     margin-bottom: 20px;
   }
 
@@ -687,7 +696,6 @@ h5 strong a:hover {
   .award-overlapped-fourth {
     position: relative;
     left: 0%;
-    margin-top: -10px;
     margin-bottom: 20px;
   }
 


### PR DESCRIPTION
Ticket Link: [WEB 297] <https://consultwithcase.atlassian.net/browse/WEB-297>
Fixed the mobile awards display to look similar to the desktop display, this should make the awards into rows instead of a single column.