### PR TITLE
WEB 297 - Awards on mobile display  

### DIFF
--- a/public/assets/custom/css/custom.css
+++ b/public/assets/custom/css/custom.css
@@ -41,30 +41,30 @@ body {
   height: auto;
 }
 
-.award-overlapped-first,
-.award-overlapped-fourth {
+.award-overlapped-1,
+.award-overlapped-4 {
   position: absolute;
   left: -10%;
 }
 
-.award-overlapped-second,
-.award-overlapped-fifth {
+.award-overlapped-2,
+.award-overlapped-5 {
   position: relative;
   left: 20%;
 }
 
-.award-overlapped-third,
-.award-overlapped-sixth {
+.award-overlapped-3,
+.award-overlapped-6 {
   position: absolute;
   left: 50%;
 }
 
-/* .award-overlapped-fourth {
+/* .award-overlapped-4 {
   position: relative;
   left: 4.5%;
 } */
 
-/* .award-overlapped-fifth {
+/* .award-overlapped-5 {
   position: relative;
   left: -6%;
 } */
@@ -571,42 +571,42 @@ h5 strong a:hover {
 
 /* for ipads and ipad pros -awards section */
 @media screen and (min-width: 768px) and (max-width: 1024px) {
-  .award-overlapped-first {
+  .award-overlapped-1 {
     position: absolute;
     left: 5%;
     margin-top: 5%;
     margin-bottom: 0%;
   }
 
-  .award-overlapped-second {
+  .award-overlapped-2 {
     position: relative;
     left: 35%;
     margin-top: 5%;
     margin-bottom: 0%;
   }
 
-  .award-overlapped-third {
+  .award-overlapped-3 {
     position: absolute;
     left: 65%;
     margin-top: 5%;
     margin-bottom: 0%;
   }
 
-  .award-overlapped-fourth {
+  .award-overlapped-4 {
     position: absolute;
     left: 5%;
     margin-top: 0%;
     margin-bottom: 10%;
   }
 
-  .award-overlapped-fifth {
+  .award-overlapped-5 {
     position: relative;
     left: 35%;
     margin-top: 0%;
     margin-bottom: 10%;
   }
 
-  .award-overlapped-sixth {
+  .award-overlapped-6 {
     position: absolute;
     left: 65%;
     margin-top: 0%;
@@ -656,7 +656,7 @@ h5 strong a:hover {
   .award-container {
     text-align: center;
     display: flex;
-    flex-direction: row;
+    flex-flow: row;
     justify-content: center;
   }
 
@@ -673,40 +673,40 @@ h5 strong a:hover {
     display: inline-block;
   }
 
-  .award-overlapped-first {
+  .award-overlapped-1 {
     position: relative;
     left: 0%;
     margin-bottom: 20px;
   }
 
-  .award-overlapped-second {
-    position: relative;
-    left: 0%;
-    margin-top: -10px;
-    margin-bottom: 20px;
-  }
-
-  .award-overlapped-third {
+  .award-overlapped-2 {
     position: relative;
     left: 0%;
     margin-top: -10px;
     margin-bottom: 20px;
   }
 
-  .award-overlapped-fourth {
-    position: relative;
-    left: 0%;
-    margin-bottom: 20px;
-  }
-
-  .award-overlapped-fifth {
+  .award-overlapped-3 {
     position: relative;
     left: 0%;
     margin-top: -10px;
     margin-bottom: 20px;
   }
 
-  .award-overlapped-sixth {
+  .award-overlapped-4 {
+    position: relative;
+    left: 0%;
+    margin-bottom: 20px;
+  }
+
+  .award-overlapped-5 {
+    position: relative;
+    left: 0%;
+    margin-top: -10px;
+    margin-bottom: 20px;
+  }
+
+  .award-overlapped-6 {
     position: relative;
     left: 0%;
     margin-top: -10px;

--- a/public/assets/custom/css/custom.css
+++ b/public/assets/custom/css/custom.css
@@ -655,18 +655,27 @@ h5 strong a:hover {
 
   .award-container {
     text-align: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
   }
 
   .award-row {
-    margin-left: -10px;
+    margin-left: -10%;
+    margin-right: -10%;
     max-width: inherit;
     position: relative;
+    display: inline-block;
+  }
+  
+  .award-row + .award-row { /* Second Award Row */
+    margin-left: -3%; 
+    display: inline-block;
   }
 
   .award-overlapped-first {
     position: relative;
     left: 0%;
-    margin-top: 10px;
     margin-bottom: 20px;
   }
 
@@ -687,7 +696,6 @@ h5 strong a:hover {
   .award-overlapped-fourth {
     position: relative;
     left: 0%;
-    margin-top: -10px;
     margin-bottom: 20px;
   }
 

--- a/src/components/home/Awards.vue
+++ b/src/components/home/Awards.vue
@@ -16,90 +16,24 @@
           <div class="col-lg-7 col-sm-12">
             <div class="container-fluid award-container">
               <div class="row award-row">
-                <div class="col-md-5 award-overlapped-first">
-                  <a
-                    href="https://www.bizjournals.com/washington/news/2017/05/05/these-are-the-best-places-to-work-in-greater.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2017.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
-                  </a>
-                </div>
-                <div class="col-md-5 award-overlapped-second">
-                  <a
-                    href="https://www.bizjournals.com/washington/news/2018/04/13/see-the-best-places-to-work-in-greater-washington.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2018.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
-                  </a>
-                </div>
-                <div class="col-md-5 award-overlapped-third">
-                  <a
-                    href="https://www.bizjournals.com/washington/subscriber-only/2019/05/17/best-places-to-work-medium-companies.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2019.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
+                <div
+                  :class="'col-md-5 award-overlapped-' + (index + 1)"
+                  v-for="(award, index) in awardsArray.slice(0, 3)"
+                  :key="index"
+                >
+                  <a :href="award.href" target="_blank" rel="noopener" border="0">
+                    <img :src="award.src" alt class="rounded-circle img-fluid mobile-image award-shadow" />
                   </a>
                 </div>
               </div>
               <div class="row award-row">
-                <div class="col-md-5 award-overlapped-fourth">
-                  <a
-                    href="https://www.bizjournals.com/washington/news/2020/05/15/best-places-to-work-honorees-covid19-response.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2020.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
-                  </a>
-                </div>
-                <div class="col-md-5 award-overlapped-fifth">
-                  <a
-                    href="https://www.bizjournals.com/washington/subscriber-only/2021/05/21/best-places-to-work-medium-companies.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2021.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
-                  </a>
-                </div>
-                <div class="col-md-5 award-overlapped-sixth">
-                  <a
-                    href="https://www.bizjournals.com/washington/subscriber-only/2022/05/13/best-places-to-work-large-companies.html"
-                    target="_blank"
-                    rel="noopener"
-                    border="0"
-                  >
-                    <img
-                      src="../../../public/assets/custom/img/awards/BPTW-2022.png"
-                      alt
-                      class="rounded-circle img-fluid mobile-image award-shadow"
-                    />
+                <div
+                  :class="'col-md-5 award-overlapped-' + (index + 1)"
+                  v-for="(award, index) in awardsArray.slice(3, 6)"
+                  :key="index"
+                >
+                  <a :href="award.href" target="_blank" rel="noopener" border="0">
+                    <img :src="award.src" alt class="rounded-circle img-fluid mobile-image award-shadow" />
                   </a>
                 </div>
               </div>
@@ -149,3 +83,50 @@
   </section>
   <!-- End Awards Section -->
 </template>
+
+<script>
+import Img2017 from '../../../public/assets/custom/img/awards/BPTW-2017.png';
+import Img2018 from '../../../public/assets/custom/img/awards/BPTW-2018.png';
+import Img2019 from '../../../public/assets/custom/img/awards/BPTW-2019.png';
+import Img2020 from '../../../public/assets/custom/img/awards/BPTW-2020.png';
+import Img2021 from '../../../public/assets/custom/img/awards/BPTW-2021.png';
+import Img2022 from '../../../public/assets/custom/img/awards/BPTW-2022.png';
+export default {
+  setup() {
+    let awardsArray = [
+      {
+        href: 'https://www.bizjournals.com/washington/news/2017/05/05/these-are-the-best-places-to-work-in-greater.html',
+        src: Img2017
+      },
+      {
+        href: 'https://www.bizjournals.com/washington/news/2018/04/13/see-the-best-places-to-work-in-greater-washington.html',
+        src: Img2018
+      },
+      {
+        href: 'https://www.bizjournals.com/washington/subscriber-only/2019/05/17/best-places-to-work-medium-companies.html',
+        src: Img2019
+      },
+      {
+        href: 'https://www.bizjournals.com/washington/news/2020/05/15/best-places-to-work-honorees-covid19-response.html',
+        src: Img2020
+      },
+      {
+        href: 'https://www.bizjournals.com/washington/subscriber-only/2021/05/21/best-places-to-work-medium-companies.html',
+        src: Img2021
+      },
+      {
+        href: 'https://www.bizjournals.com/washington/subscriber-only/2022/05/13/best-places-to-work-large-companies.html',
+        src: Img2022
+      }
+    ];
+
+    const windowWidth = window.innerWidth;
+    if (windowWidth < 767) {
+      awardsArray = [awardsArray[0], awardsArray[2], awardsArray[4], awardsArray[1], awardsArray[3], awardsArray[5]];
+    }
+    return {
+      awardsArray
+    };
+  }
+};
+</script>


### PR DESCRIPTION
Ticket Link: [WEB 297] <https://consultwithcase.atlassian.net/browse/WEB-297>
Changed BPTW awards to be chronologically left to right top down in two columns on mobile displays instead of in one column.

How to test: Go to awards and change display size to mobile, then refresh page (order doesn't change when display size changes).